### PR TITLE
[Bugfix] Fix reading crashing updating executors from different threads (#38)

### DIFF
--- a/Sources/CentralManager/CentralManagerContext.swift
+++ b/Sources/CentralManager/CentralManagerContext.swift
@@ -54,10 +54,10 @@ class CentralManagerContext {
         return executor
     }()
     
-    private var flushableExecutors: [FlushableExecutor] = []
+    private var flushableExecutors: ThreadSafeArray<FlushableExecutor> = []
     
     func flush(error: Error) async throws {
-        for flushableExecutor in flushableExecutors {
+        for try await flushableExecutor in flushableExecutors {
             try await flushableExecutor.flush(error: error)
         }
     }

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -67,10 +67,8 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         
         if characteristic.isNotifying {
-           
            // characteristic.value is Data() and it will get trampled if allowed to run async.
            self.context.characteristicValueUpdatedSubject.send( Characteristic(characteristic) )
-
         }
            
         Task {
@@ -168,5 +166,9 @@ extension PeripheralDelegate: CBPeripheralDelegate {
                 Self.logger.warning("Received OpenChannel result without a continuation")
             }
         }
+    }
+    
+    func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+        self.context.invalidatedServicesSubject.send(invalidatedServices.map { Service($0) })
     }
 }

--- a/Sources/Utils/ThreadSafeArray.swift
+++ b/Sources/Utils/ThreadSafeArray.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 Manuel Fernandez. All rights reserved.
+
+import Foundation
+
+actor ThreadSafeArray<Element> {
+    
+    private var array: [Element]
+    
+    init(array: [Element] = []) {
+        self.array = array
+    }
+    
+    nonisolated func append(_ element: Element) {
+        Task {
+            await self.append(element)
+        }
+    }
+    
+    func append(_ element: Element) async {
+        array.append(element)
+    }
+}
+
+extension ThreadSafeArray: AsyncSequence {
+    struct AsyncIterator: AsyncIteratorProtocol {
+        private let threadSafeArray: ThreadSafeArray
+        private var iterator: Array<Element>.Iterator?
+        
+        init(threadSafeArray: ThreadSafeArray) {
+            self.threadSafeArray = threadSafeArray
+        }
+
+        mutating func next() async throws -> Element? {
+            if iterator == nil {
+                iterator = await threadSafeArray.array.makeIterator()
+            }
+            return iterator?.next()
+        }
+    }
+
+    nonisolated func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(threadSafeArray: self)
+    }
+}
+
+extension ThreadSafeArray: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: Element...) {
+        self.init(array: elements)
+    }
+}


### PR DESCRIPTION
Pulling from upstream

- Add missing didModifyServices to peripheral delegate.
- Use thread safe array in contexts

Here's the upstream commit from the package author
https://github.com/manolofdez/AsyncBluetooth/pull/38